### PR TITLE
Removing unused Acrylic References

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/UnsafeNativeMethodsWindow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/UnsafeNativeMethodsWindow.cs
@@ -214,46 +214,6 @@ internal static class UnsafeNativeMethodsWindow
     }
 
     /// <summary>
-    /// Tries to apply legacy Acrylic effect for the selected <see cref="Window"/>.
-    /// </summary>
-    /// <param name="window">The window to which the effect is to be applied.</param>
-    /// <returns><see langword="true"/> if invocation of native Windows function succeeds.</returns>
-    public static bool ApplyWindowLegacyAcrylicEffect(Window window) =>
-        GetHandle(window, out IntPtr windowHandle) && ApplyWindowLegacyAcrylicEffect(windowHandle);
-
-    /// <summary>
-    /// Tries to apply legacy Acrylic effect for the selected <see cref="Window"/>.
-    /// </summary>
-    /// <param name="handle">Window handle</param>
-    /// <returns><see langword="true"/> if invocation of native Windows function succeeds.</returns>
-    public static bool ApplyWindowLegacyAcrylicEffect(IntPtr handle)
-    {
-        var accentPolicy = new ACCENT_POLICY
-        {
-            nAccentState = ACCENT_STATE.ACCENT_ENABLE_ACRYLICBLURBEHIND,
-            nColor = 0x990000 & 0xFFFFFF
-        };
-
-        var accentStructSize = Marshal.SizeOf(accentPolicy);
-        var accentPtr = Marshal.AllocHGlobal(accentStructSize);
-
-        Marshal.StructureToPtr(accentPolicy, accentPtr, false);
-
-        var data = new WINCOMPATTRDATA
-        {
-            Attribute = WCA.WCA_ACCENT_POLICY,
-            SizeOfData = accentStructSize,
-            Data = accentPtr
-        };
-
-        _ = NativeMethods.SetWindowCompositionAttribute(handle, ref data);
-
-        Marshal.FreeHGlobal(accentPtr);
-
-        return true;
-    }
-
-    /// <summary>
     /// Tries to get currently selected Window accent color.
     /// </summary>
     public static Color GetDwmColor()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
@@ -2278,87 +2278,6 @@ namespace Standard
         public ulong cBuffersEmpty;
     }
 
-    /// <summary>
-    /// Window composition attributes.
-    /// </summary>
-    internal enum WCA
-    {
-        WCA_UNDEFINED = 0,
-        WCA_NCRENDERING_ENABLED = 1,
-        WCA_NCRENDERING_POLICY = 2,
-        WCA_TRANSITIONS_FORCEDISABLED = 3,
-        WCA_ALLOW_NCPAINT = 4,
-        WCA_CAPTION_BUTTON_BOUNDS = 5,
-        WCA_NONCLIENT_RTL_LAYOUT = 6,
-        WCA_FORCE_ICONIC_REPRESENTATION = 7,
-        WCA_EXTENDED_FRAME_BOUNDS = 8,
-        WCA_HAS_ICONIC_BITMAP = 9,
-        WCA_THEME_ATTRIBUTES = 10,
-        WCA_NCRENDERING_EXILED = 11,
-        WCA_NCADORNMENTINFO = 12,
-        WCA_EXCLUDED_FROM_LIVEPREVIEW = 13,
-        WCA_VIDEO_OVERLAY_ACTIVE = 14,
-        WCA_FORCE_ACTIVEWINDOW_APPEARANCE = 15,
-        WCA_DISALLOW_PEEK = 16,
-        WCA_CLOAK = 17,
-        WCA_CLOAKED = 18,
-        WCA_ACCENT_POLICY = 19,
-        WCA_FREEZE_REPRESENTATION = 20,
-        WCA_EVER_UNCLOAKED = 21,
-        WCA_VISUAL_OWNER = 22,
-        WCA_HOLOGRAPHIC = 23,
-        WCA_EXCLUDED_FROM_DDA = 24,
-        WCA_PASSIVEUPDATEMODE = 25,
-        WCA_USEDARKMODECOLORS = 26,
-        WCA_CORNER_STYLE = 27,
-        WCA_PART_COLOR = 28,
-        WCA_DISABLE_MOVESIZE_FEEDBACK = 29,
-        WCA_LAST = 30
-    }
-
-    [Flags]
-    internal enum ACCENT_FLAGS
-    {
-        DrawLeftBorder = 0x20,
-        DrawTopBorder = 0x40,
-        DrawRightBorder = 0x80,
-        DrawBottomBorder = 0x100,
-        DrawAllBorders = DrawLeftBorder | DrawTopBorder | DrawRightBorder | DrawBottomBorder
-    }
-
-    /// <summary>
-    /// DWM window accent state.
-    /// </summary>
-    internal enum ACCENT_STATE
-    {
-        ACCENT_DISABLED = 0,
-        ACCENT_ENABLE_GRADIENT = 1,
-        ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
-        ACCENT_ENABLE_BLURBEHIND = 3,
-        ACCENT_ENABLE_ACRYLICBLURBEHIND = 4,
-        ACCENT_INVALID_STATE = 5
-    }
-
-    /// <summary>
-    /// WCA window accent policy.
-    /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct ACCENT_POLICY
-    {
-        public ACCENT_STATE nAccentState;
-        public uint nFlags;
-        public uint nColor;
-        public uint nAnimationId;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct WINCOMPATTRDATA
-    {
-        public WCA Attribute;
-        public IntPtr Data;
-        public int SizeOfData;
-    }
-
     #endregion
 
     /// <summary>Delegate declaration that matches native WndProc signatures.</summary>
@@ -2621,18 +2540,7 @@ namespace Standard
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool IsWindow(IntPtr hwnd);
-        /// <summary>
-        /// Sets various information regarding DWM window attributes.
-        /// </summary>
-        [DllImport("user32.dll")]
-        public static extern int SetWindowCompositionAttribute([In] IntPtr hWnd, [In, Out] ref WINCOMPATTRDATA data);
-
-        /// <summary>
-        /// Sets various information regarding DWM window attributes.
-        /// </summary>
-        [DllImport("user32.dll")]
-        public static extern int GetWindowCompositionAttribute([In] IntPtr hWnd,[In, Out] ref WINCOMPATTRDATA data);
-
+        
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("dwmapi.dll", PreserveSig = false)]
         public static extern void DwmExtendFrameIntoClientArea(IntPtr hwnd, ref MARGINS pMarInset);


### PR DESCRIPTION
Removing Unused Acrylic background references, not being currently used in Fluent Windows Styling.
