### PR TITLE
Fetching Accent Colors using RoActivateInstance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT.cs
@@ -69,6 +69,9 @@ namespace WinRT
         [DllImport("api-ms-win-core-winrt-l1-1-0.dll")]
         public static extern unsafe int RoGetActivationFactory(IntPtr runtimeClassId, ref Guid iid, IntPtr* factory);
 
+        [DllImport("api-ms-win-core-winrt-l1-1-0.dll")]
+        public static extern unsafe int RoActivateInstance(IntPtr runtimeClassId, IntPtr* instance);
+
         [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll", CallingConvention = CallingConvention.StdCall)]
         public static extern unsafe int WindowsCreateString([MarshalAs(UnmanagedType.LPWStr)] string sourceString,
                                                   int length,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/Windows.UI.ViewManagement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/Windows.UI.ViewManagement.cs
@@ -56,26 +56,15 @@ namespace MS.Internal.WindowsRuntime
                 IUISettings3* uiSettings3;
                 Marshal.ThrowExceptionForHR(inspectable->QueryInterface(&guid, (void**)&uiSettings3));
                 _uiSettings3 = uiSettings3;
-
-                // Marshal.ThrowExceptionForHR(WinRT.RoActivateInstance(hstring, out IntPtr punk));
-
-                // WinRT.WindowsDeleteString(hstring);
-
-                // Guid guid = IID_IUISettings3;
-                // Marshal.ThrowExceptionForHR(Marshal.QueryInterface(punk, in guid, out IntPtr ppUnk));
-                // IUISettings3 uiSettings3 = (IUISettings3)Marshal.PtrToStructure(ppUnk, typeof(IUISettings3));
-                
-                // _uiSettings3 = &uiSettings3;
-
             }
 
             public Color AccentColor => _uiSettings3->GetColorValue(UIColorType.Accent);
-            public Color AccentColor1 => _uiSettings3->GetColorValue(UIColorType.AccentDark1);
-            public Color AccentColor2 => _uiSettings3->GetColorValue(UIColorType.AccentDark2);
-            public Color AccentColor3 => _uiSettings3->GetColorValue(UIColorType.AccentDark3);
-            public Color AccentColor4 => _uiSettings3->GetColorValue(UIColorType.AccentLight1);
-            public Color AccentColor5 => _uiSettings3->GetColorValue(UIColorType.AccentLight2);
-            public Color AccentColor6 => _uiSettings3->GetColorValue(UIColorType.AccentLight3);
+            public Color AccentDark1 => _uiSettings3->GetColorValue(UIColorType.AccentDark1);
+            public Color AccentDark2 => _uiSettings3->GetColorValue(UIColorType.AccentDark2);
+            public Color AccentDark3 => _uiSettings3->GetColorValue(UIColorType.AccentDark3);
+            public Color AccentLight1 => _uiSettings3->GetColorValue(UIColorType.AccentLight1);
+            public Color AccentLight2 => _uiSettings3->GetColorValue(UIColorType.AccentLight2);
+            public Color AccentLight3 => _uiSettings3->GetColorValue(UIColorType.AccentLight3);
 
             // Extract of the IUISettings3 from windows.ui.viewmanagement.idl
             private struct IUISettings3
@@ -88,7 +77,7 @@ namespace MS.Internal.WindowsRuntime
                     // The GetColorValue method comes right after IInspectable and is at VTBL slot 6
                     ((delegate* unmanaged<IUISettings3*, UIColorType, UIColor*, int>)(lpVtbl[6]))((IUISettings3*)Unsafe.AsPointer(ref this), desiredColor, &value);
 
-                    return Color.FromUInt32((uint)*(int*)&value);
+                    return Color.FromArgb(value.A, value.R, value.G, value.B);
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/Windows.UI.ViewManagement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/Windows.UI.ViewManagement.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using WinRT;
+using WinRT.Interop;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Windows.Media;
+
+#pragma warning disable CS0649
+
+
+namespace MS.Internal.WindowsRuntime
+{
+    namespace Windows.UI.ViewManagement
+    {
+        internal static unsafe partial class WinRT
+        {
+            [DllImport("combase.dll", CallingConvention = CallingConvention.StdCall)]
+            internal static extern unsafe int WindowsCreateString([MarshalAs(UnmanagedType.LPWStr)] string sourceString,
+                                                  int length,
+                                                  out IntPtr hstring);
+
+            [DllImport("combase.dll", CallingConvention = CallingConvention.StdCall)]
+            internal static extern int WindowsDeleteString(IntPtr hstring);
+
+
+            /// <include file='WinRT.xml' path='doc/member[@name="WinRT.RoActivateInstance"]/*' />
+            [DllImport("combase.dll", CallingConvention = CallingConvention.StdCall)]
+            public static extern int RoActivateInstance(IntPtr activatableClassId, IInspectable** instance);
+            // public static extern int RoActivateInstance(IntPtr activatableClassId, out IntPtr instance);
+        }
+        
+        internal unsafe class Win32WindowSettings
+        {
+            private readonly IUISettings3* _uiSettings3;
+
+            // private static readonly Guid IID_IUISettings3 = Guid.Parse("03021BE4-5254-4781-8194-5168F7D06D7B");
+
+            public Win32WindowSettings()
+            {
+                const string uiSettingsClassName = "Windows.UI.ViewManagement.UISettings";
+                IntPtr hstring;
+                Marshal.ThrowExceptionForHR(WinRT.WindowsCreateString(uiSettingsClassName, uiSettingsClassName.Length, out hstring));
+
+                IInspectable* inspectable;
+                Marshal.ThrowExceptionForHR(WinRT.RoActivateInstance(hstring, &inspectable));
+                WinRT.WindowsDeleteString(hstring);
+
+                var guid = new Guid("03021BE4-5254-4781-8194-5168F7D06D7B");
+                IUISettings3* uiSettings3;
+                Marshal.ThrowExceptionForHR(inspectable->QueryInterface(&guid, (void**)&uiSettings3));
+                _uiSettings3 = uiSettings3;
+
+                // Marshal.ThrowExceptionForHR(WinRT.RoActivateInstance(hstring, out IntPtr punk));
+
+                // WinRT.WindowsDeleteString(hstring);
+
+                // Guid guid = IID_IUISettings3;
+                // Marshal.ThrowExceptionForHR(Marshal.QueryInterface(punk, in guid, out IntPtr ppUnk));
+                // IUISettings3 uiSettings3 = (IUISettings3)Marshal.PtrToStructure(ppUnk, typeof(IUISettings3));
+                
+                // _uiSettings3 = &uiSettings3;
+
+            }
+
+            public Color AccentColor => _uiSettings3->GetColorValue(UIColorType.Accent);
+            public Color AccentColor1 => _uiSettings3->GetColorValue(UIColorType.AccentDark1);
+            public Color AccentColor2 => _uiSettings3->GetColorValue(UIColorType.AccentDark2);
+            public Color AccentColor3 => _uiSettings3->GetColorValue(UIColorType.AccentDark3);
+            public Color AccentColor4 => _uiSettings3->GetColorValue(UIColorType.AccentLight1);
+            public Color AccentColor5 => _uiSettings3->GetColorValue(UIColorType.AccentLight2);
+            public Color AccentColor6 => _uiSettings3->GetColorValue(UIColorType.AccentLight3);
+
+            // Extract of the IUISettings3 from windows.ui.viewmanagement.idl
+            private struct IUISettings3
+            {
+                public void** lpVtbl;
+
+                public Color GetColorValue(UIColorType desiredColor)
+                {
+                    UIColor value;
+                    // The GetColorValue method comes right after IInspectable and is at VTBL slot 6
+                    ((delegate* unmanaged<IUISettings3*, UIColorType, UIColor*, int>)(lpVtbl[6]))((IUISettings3*)Unsafe.AsPointer(ref this), desiredColor, &value);
+
+                    return Color.FromUInt32((uint)*(int*)&value);
+                }
+            }
+
+            private enum UIColorType
+            {
+                Background = 0,
+                Foreground = 1,
+                AccentDark3 = 2,
+                AccentDark2 = 3,
+                AccentDark1 = 4,
+                Accent = 5,
+                AccentLight1 = 6,
+                AccentLight2 = 7,
+                AccentLight3 = 8,
+                Complement = 9
+            };
+
+            private readonly record struct UIColor(byte A, byte R, byte G, byte B);
+
+        }
+
+        [Guid("AF86E2E0-B12D-4C6A-9C5A-D7AA65101E90")]
+        internal unsafe partial struct IInspectable
+        {
+
+            public void** lpVtbl;
+
+            /// <inheritdoc cref="IUnknown.QueryInterface" />
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int QueryInterface(Guid* riid, void** ppvObject)
+            {
+                return ((delegate* unmanaged<IInspectable*, Guid*, void**, int>)(lpVtbl[0]))((IInspectable*)Unsafe.AsPointer(ref this), riid, ppvObject);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DWMColorization.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DWMColorization.cs
@@ -20,58 +20,15 @@ internal static class DwmColorization
         get { return _currentApplicationAccentColor; }
     }
 
-    [DllImport("UXTheme.dll")]
-    private static extern int GetUserColorPreference(in IMMERSIVE_COLOR_PREFERENCE colorPreference, bool alwaysFalse);
-
-    [DllImport("UXTheme.dll")]
-    private static extern uint GetColorFromPreference(in IMMERSIVE_COLOR_PREFERENCE colorPreference, IMMERSIVE_COLOR_TYPE colorType, bool isHighContrastEnabled, IMMERSIVE_HC_CACHE_MODE cacheMode);
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct IMMERSIVE_COLOR_PREFERENCE
-    {
-        public uint crStartColor;
-        public uint crAccentColor;
-    }
-
-    private enum IMMERSIVE_COLOR_TYPE
-    {
-        IMCLR_SystemAccentLight1 = 5,
-        IMCLR_SystemAccentLight2 = 6,
-        IMCLR_SystemAccentLight3 = 7,
-        IMCLR_SystemAccentDark1 = 3,
-        IMCLR_SystemAccentDark2 = 2,
-        IMCLR_SystemAccentDark3 = 1,
-        IMCLR_SystemAccent = 4
-    }
-
-    private enum IMMERSIVE_HC_CACHE_MODE
-    {
-        IHCM_USE_CACHED_VALUE = 0,
-        IHCM_REFRESH = 1
-    }
-
     /// <summary>
     /// Gets the system accent color.
     /// </summary>
     /// <returns>Updated <see cref="System.Windows.Media.Color"/> Accent Color.</returns>
     internal static Color GetSystemAccentColor()
     {
-        bool isHighContrastEnabled = SystemParameters.HighContrast;
-      
-        IMMERSIVE_COLOR_PREFERENCE colorPreference = new IMMERSIVE_COLOR_PREFERENCE();
+        Win32WindowSettings _uiSettings3 = new Win32WindowSettings();
 
-        int err = GetUserColorPreference(in colorPreference, false);
-
-        if (err != 0)
-        {
-            return Color.FromArgb(0xff, 0x00, 0x78, 0xd4);
-        }
-        else
-        {
-            uint AccentColor = GetColorFromPreference(in colorPreference, IMMERSIVE_COLOR_TYPE.IMCLR_SystemAccent, isHighContrastEnabled, IMMERSIVE_HC_CACHE_MODE.IHCM_REFRESH);
-
-            return Color.FromArgb(0xff, (byte)AccentColor, (byte)(AccentColor >> 8), (byte)(AccentColor >> 16));
-        }
+        return _uiSettings3.AccentColor;
     }
 
     /// <summary>
@@ -79,63 +36,24 @@ internal static class DwmColorization
     /// </summary>
     internal static void UpdateAccentColors()
     {
-        Win32WindowSettings obj = new Win32WindowSettings();
+        Win32WindowSettings _uiSettings3 = new Win32WindowSettings();
 
-        var color1 = obj.AccentColor;
-        var color2 = obj.AccentColor1;
-        var color3 = obj.AccentColor2;
-        var color4 = obj.AccentColor3;
-        var color5 = obj.AccentColor4;
-        var color6 = obj.AccentColor5;
-        var color7 = obj.AccentColor6;
-
-        // UISettings uiSettings = new UISettings();
-        // var colorType = UISettingsRCW.UIColorType.Accent;
-        // var acc = uiSettings.GetColorValue(colorType);
-        // var acc1 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentDark1);
-        // var acc2 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentDark2);
-        // var acc3 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentDark3);
-        // var acc4 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentLight1);
-        // var acc5 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentLight2);
-        // var acc6 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentLight3);
-
-        Color systemAccent = GetSystemAccentColor();
-
+        Color systemAccent = _uiSettings3.AccentColor;
         Color primaryAccent;
         Color secondaryAccent;
         Color tertiaryAccent;
 
-        bool isDarkTheme = ThemeColorization.IsThemeDark();
-        bool isHighContrastEnabled = SystemParameters.HighContrast;
-
-        IMMERSIVE_COLOR_PREFERENCE colorPreference = new IMMERSIVE_COLOR_PREFERENCE();
-
-        int err = GetUserColorPreference(in colorPreference, false);
-
-        if(err != 0) 
+        if (ThemeColorization.IsThemeDark())
         {
-            primaryAccent = secondaryAccent = tertiaryAccent = systemAccent;
+            primaryAccent = _uiSettings3.AccentLight1;
+            secondaryAccent = _uiSettings3.AccentLight2;
+            tertiaryAccent = _uiSettings3.AccentLight3;
         }
         else
         {
-            uint Accent1, Accent2, Accent3;
-
-            if (isDarkTheme)
-            {
-                Accent1 = GetColorFromPreference(in colorPreference, IMMERSIVE_COLOR_TYPE.IMCLR_SystemAccentDark1, isHighContrastEnabled, IMMERSIVE_HC_CACHE_MODE.IHCM_REFRESH);
-                Accent2 = GetColorFromPreference(in colorPreference, IMMERSIVE_COLOR_TYPE.IMCLR_SystemAccentDark2, isHighContrastEnabled, IMMERSIVE_HC_CACHE_MODE.IHCM_REFRESH);
-                Accent3 = GetColorFromPreference(in colorPreference, IMMERSIVE_COLOR_TYPE.IMCLR_SystemAccentDark3, isHighContrastEnabled, IMMERSIVE_HC_CACHE_MODE.IHCM_REFRESH);
-            }
-            else
-            {
-                Accent1 = GetColorFromPreference(in colorPreference, IMMERSIVE_COLOR_TYPE.IMCLR_SystemAccentLight1, isHighContrastEnabled, IMMERSIVE_HC_CACHE_MODE.IHCM_REFRESH);
-                Accent2 = GetColorFromPreference(in colorPreference, IMMERSIVE_COLOR_TYPE.IMCLR_SystemAccentLight2, isHighContrastEnabled, IMMERSIVE_HC_CACHE_MODE.IHCM_REFRESH);
-                Accent3 = GetColorFromPreference(in colorPreference, IMMERSIVE_COLOR_TYPE.IMCLR_SystemAccentLight3, isHighContrastEnabled, IMMERSIVE_HC_CACHE_MODE.IHCM_REFRESH);
-            }
-
-            primaryAccent = Color.FromArgb(0xff, (byte)Accent1, (byte)(Accent1 >> 8), (byte)(Accent1 >> 16));
-            secondaryAccent = Color.FromArgb(0xff, (byte)Accent2, (byte)(Accent2 >> 8), (byte)(Accent2 >> 16));
-            tertiaryAccent = Color.FromArgb(0xff, (byte)Accent3, (byte)(Accent3 >> 8), (byte)(Accent3 >> 16));
+            primaryAccent = _uiSettings3.AccentDark1;
+            secondaryAccent = _uiSettings3.AccentDark2;
+            tertiaryAccent = _uiSettings3.AccentDark3;
         }
 
         UpdateColorResources(systemAccent, primaryAccent, secondaryAccent, tertiaryAccent);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DWMColorization.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DWMColorization.cs
@@ -5,6 +5,7 @@ using System.Windows.Media;
 using Microsoft.Win32;
 using MS.Internal;
 using System.Runtime.InteropServices;
+using MS.Internal.WindowsRuntime.Windows.UI.ViewManagement;
 
 namespace System.Windows;
 internal static class DwmColorization
@@ -78,6 +79,26 @@ internal static class DwmColorization
     /// </summary>
     internal static void UpdateAccentColors()
     {
+        Win32WindowSettings obj = new Win32WindowSettings();
+
+        var color1 = obj.AccentColor;
+        var color2 = obj.AccentColor1;
+        var color3 = obj.AccentColor2;
+        var color4 = obj.AccentColor3;
+        var color5 = obj.AccentColor4;
+        var color6 = obj.AccentColor5;
+        var color7 = obj.AccentColor6;
+
+        // UISettings uiSettings = new UISettings();
+        // var colorType = UISettingsRCW.UIColorType.Accent;
+        // var acc = uiSettings.GetColorValue(colorType);
+        // var acc1 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentDark1);
+        // var acc2 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentDark2);
+        // var acc3 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentDark3);
+        // var acc4 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentLight1);
+        // var acc5 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentLight2);
+        // var acc6 = uiSettings.GetColorValue(UISettingsRCW.UIColorType.AccentLight3);
+
         Color systemAccent = GetSystemAccentColor();
 
         Color primaryAccent;


### PR DESCRIPTION
## Description
To implement the fetching of system accent colors, we had used `UxTheme`'s undocumented APIs, namely `GetUserColorPreference` and `GetColorFromPreference`. As it turns out, this is not the most ideal way of doing so. We have re-worked its implementation in this PR by fetching the instance of `UISettings` class via `RoActivateInstance`.  The changes in this PR deals with addition of the above discussed method and removal of the undocumented APIs.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
_Minimal_
<!-- What is the impact to customers of not taking this fix? -->

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
1. Local Build Pass
2. Sample Application Testing
3. Matching the fetched color values with expected values
<!-- What kind of testing has been done with the fix. -->
