### PR TITLE
Fix (Fluent): Usage of defined resources as StaticResources

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -459,9 +459,13 @@ namespace System.Windows
 
             // Here we are syncing the window's Theme mode if resource dictionary changes.
             // The IgnoreWindowResourcesChange is a flag set to make sure the ThemeMode change does not cause an infinite loop of resource changes.
-            if(fe is Window currentWindow && !ThemeManager.IgnoreWindowResourcesChange)
+            if(fe is Window currentWindow)
             {
-                ThemeManager.SyncWindowThemeModeAndResources(currentWindow);
+                currentWindow.IsWindowsResourcesInitialized = true;
+                if(!ThemeManager.IgnoreWindowResourcesChange)
+                {
+                    ThemeManager.SyncWindowThemeModeAndResources(currentWindow);
+                }
             }
 
             // We're interested in changes to the Template property that occur during

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -583,6 +583,14 @@ namespace System.Windows
                 ThemeMode oldTheme = _themeMode;
                 _themeMode = value;
                 
+                if(!IsWindowsResourcesInitialized)
+                {
+                    ThemeManager.OnWindowThemeChanged(this, oldTheme, value);
+                    IsWindowsResourcesInitialized = false;
+
+                    ReloadWindowsFluentDictionary = true;
+                }
+
                 if(IsSourceWindowNull)
                 {
                     _deferThemeLoading = true;
@@ -3292,6 +3300,31 @@ namespace System.Windows
         {
             get { return false; }
         }
+
+        internal bool ReloadWindowsFluentDictionary
+        {
+            get
+            {
+                return _reloadWindowsFluentDictionary;
+            }
+            set
+            {
+                _reloadWindowsFluentDictionary = value;
+            }
+        }
+
+        internal bool IsWindowsResourcesInitialized
+        {
+            get
+            {
+                return _windowsResourcesInitialized;
+            }
+            set
+            {
+                _windowsResourcesInitialized = value;
+            }
+        }
+
         #endregion Internal Properties
 
         //----------------------------------------------
@@ -7215,7 +7248,9 @@ namespace System.Windows
 
         private SourceWindowHelper  _swh;                               // object that will hold the window
         private Window              _ownerWindow;                       // owner window
-
+        private bool _reloadWindowsFluentDictionary = false;
+        private bool _windowsResourcesInitialized = false;
+        
         // keeps track of the owner hwnd
         // we need this one b/c a owner/parent
         // can be set through the WindowInteropHandler


### PR DESCRIPTION
Fixes: https://github.com/dotnet/wpf/issues/9557

## Description
The following changes loads the window's fluent resources to make sure that resources can be used as `StaticResource`. This fixes window's scope of the above mentioned issue.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Developers can use fluent resources as `StaticResources`.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
<!-- What kind of testing has been done with the fix. -->
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
