### PR TITLE
Fix StaticResource usage for Fluent Theme

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -731,17 +731,7 @@ namespace System.Windows
 
                 if(this is Window window)
                 {
-                    if(window.ReloadWindowsFluentDictionary && !window.IsWindowsResourcesInitialized)
-                    {
-                        if(value != null) 
-                        {
-                            var uri = ThemeManager.GetThemeResource(window.ThemeMode);
-                            value.MergedDictionaries.Insert(0, new ResourceDictionary() { Source = uri });
-                            invalidateResources = true;
-                        }
-
-                        window.ReloadWindowsFluentDictionary = false;
-                    }
+                    window.AddFluentDictionary(value, out invalidateResources);
                 }
 
                 if (value != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -461,7 +461,7 @@ namespace System.Windows
             // The IgnoreWindowResourcesChange is a flag set to make sure the ThemeMode change does not cause an infinite loop of resource changes.
             if(fe is Window currentWindow)
             {
-                currentWindow.AreWindowResourcesInitialized = true;
+                currentWindow.AreResourcesInitialized = true;
                 if(!ThemeManager.IgnoreWindowResourcesChange)
                 {
                     ThemeManager.SyncWindowThemeModeAndResources(currentWindow);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -461,7 +461,7 @@ namespace System.Windows
             // The IgnoreWindowResourcesChange is a flag set to make sure the ThemeMode change does not cause an infinite loop of resource changes.
             if(fe is Window currentWindow)
             {
-                currentWindow.IsWindowsResourcesInitialized = true;
+                currentWindow.AreWindowResourcesInitialized = true;
                 if(!ThemeManager.IgnoreWindowResourcesChange)
                 {
                     ThemeManager.SyncWindowThemeModeAndResources(currentWindow);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -459,9 +459,13 @@ namespace System.Windows
 
             // Here we are syncing the window's Theme mode if resource dictionary changes.
             // The IgnoreWindowResourcesChange is a flag set to make sure the ThemeMode change does not cause an infinite loop of resource changes.
-            if(fe is Window currentWindow && !ThemeManager.IgnoreWindowResourcesChange)
+            if(fe is Window currentWindow)
             {
-                ThemeManager.SyncWindowThemeModeAndResources(currentWindow);
+                currentWindow.IsWindowsResourcesInitialized = true;
+                if(!ThemeManager.IgnoreWindowResourcesChange)
+                {
+                    ThemeManager.SyncWindowThemeModeAndResources(currentWindow);
+                }
             }
 
             // We're interested in changes to the Template property that occur during

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -583,6 +583,14 @@ namespace System.Windows
                 ThemeMode oldTheme = _themeMode;
                 _themeMode = value;
                 
+                if(!IsWindowsResourcesInitialized)
+                {
+                    ThemeManager.OnWindowThemeChanged(this, oldTheme, value);
+                    IsWindowsResourcesInitialized = false;
+
+                    ReloadWindowsFluentDictionary = true;
+                }
+
                 if(IsSourceWindowNull)
                 {
                     _deferThemeLoading = true;
@@ -3292,6 +3300,31 @@ namespace System.Windows
         {
             get { return false; }
         }
+
+        internal bool ReloadWindowsFluentDictionary
+        {
+            get
+            {
+                return _reloadWindowsFluentDictionary;
+            }
+            set
+            {
+                _reloadWindowsFluentDictionary = value;
+            }
+        }
+
+        internal bool IsWindowsResourcesInitialized
+        {
+            get
+            {
+                return _windowsResourcesInitialized;
+            }
+            set
+            {
+                _windowsResourcesInitialized = value;
+            }
+        }
+
         #endregion Internal Properties
 
         //----------------------------------------------
@@ -7215,7 +7248,9 @@ namespace System.Windows
 
         private SourceWindowHelper  _swh;                               // object that will hold the window
         private Window              _ownerWindow;                       // owner window
-
+        private bool _reloadWindowsFluentDictionary = false;
+        private bool _windowsResourcesInitialized = false;
+        
         // keeps track of the owner hwnd
         // we need this one b/c a owner/parent
         // can be set through the WindowInteropHandler

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -583,10 +583,10 @@ namespace System.Windows
                 ThemeMode oldTheme = _themeMode;
                 _themeMode = value;
                 
-                if(!AreWindowResourcesInitialized)
+                if(!AreResourcesInitialized)
                 {
                     ThemeManager.OnWindowThemeChanged(this, oldTheme, value);
-                    AreWindowResourcesInitialized = false;
+                    AreResourcesInitialized = false;
 
                     ReloadFluentDictionary = true;
                 }
@@ -2132,7 +2132,7 @@ namespace System.Windows
         {
             invalidateResources = false;
 
-            if(this.ReloadFluentDictionary && !this.AreWindowResourcesInitialized)
+            if(this.ReloadFluentDictionary && !this.AreResourcesInitialized)
             {
                 if(value != null) 
                 {
@@ -3330,15 +3330,15 @@ namespace System.Windows
             }
         }
 
-        internal bool AreWindowResourcesInitialized
+        internal bool AreResourcesInitialized
         {
             get
             {
-                return _windowResourcesInitialized;
+                return _resourcesInitialized;
             }
             set
             {
-                _windowResourcesInitialized = value;
+                _resourcesInitialized = value;
             }
         }
 
@@ -7266,7 +7266,7 @@ namespace System.Windows
         private SourceWindowHelper  _swh;                               // object that will hold the window
         private Window              _ownerWindow;                       // owner window
         private bool _reloadFluentDictionary = false;
-        private bool _windowResourcesInitialized = false;
+        private bool _resourcesInitialized = false;
         
         // keeps track of the owner hwnd
         // we need this one b/c a owner/parent

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -583,12 +583,12 @@ namespace System.Windows
                 ThemeMode oldTheme = _themeMode;
                 _themeMode = value;
                 
-                if(!IsWindowsResourcesInitialized)
+                if(!AreWindowResourcesInitialized)
                 {
                     ThemeManager.OnWindowThemeChanged(this, oldTheme, value);
-                    IsWindowsResourcesInitialized = false;
+                    AreWindowResourcesInitialized = false;
 
-                    ReloadWindowsFluentDictionary = true;
+                    ReloadFluentDictionary = true;
                 }
 
                 if(IsSourceWindowNull)
@@ -2132,7 +2132,7 @@ namespace System.Windows
         {
             invalidateResources = false;
 
-            if(this.ReloadWindowsFluentDictionary && !this.IsWindowsResourcesInitialized)
+            if(this.ReloadFluentDictionary && !this.AreWindowResourcesInitialized)
             {
                 if(value != null) 
                 {
@@ -2141,7 +2141,7 @@ namespace System.Windows
                     invalidateResources = true;
                 }
 
-                this.ReloadWindowsFluentDictionary = false;
+                this.ReloadFluentDictionary = false;
             }
         }
 
@@ -3318,27 +3318,27 @@ namespace System.Windows
             get { return false; }
         }
 
-        private bool ReloadWindowsFluentDictionary
+        private bool ReloadFluentDictionary
         {
             get
             {
-                return _reloadWindowsFluentDictionary;
+                return _reloadFluentDictionary;
             }
             set
             {
-                _reloadWindowsFluentDictionary = value;
+                _reloadFluentDictionary = value;
             }
         }
 
-        internal bool IsWindowsResourcesInitialized
+        internal bool AreWindowResourcesInitialized
         {
             get
             {
-                return _windowsResourcesInitialized;
+                return _windowResourcesInitialized;
             }
             set
             {
-                _windowsResourcesInitialized = value;
+                _windowResourcesInitialized = value;
             }
         }
 
@@ -7265,8 +7265,8 @@ namespace System.Windows
 
         private SourceWindowHelper  _swh;                               // object that will hold the window
         private Window              _ownerWindow;                       // owner window
-        private bool _reloadWindowsFluentDictionary = false;
-        private bool _windowsResourcesInitialized = false;
+        private bool _reloadFluentDictionary = false;
+        private bool _windowResourcesInitialized = false;
         
         // keeps track of the owner hwnd
         // we need this one b/c a owner/parent

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -2131,7 +2131,7 @@ namespace System.Windows
         internal void AddFluentDictionary(ResourceDictionary value, out bool invalidateResources)
         {
             invalidateResources = false;
-            
+
             if(this.ReloadWindowsFluentDictionary && !this.IsWindowsResourcesInitialized)
             {
                 if(value != null) 
@@ -3318,7 +3318,7 @@ namespace System.Windows
             get { return false; }
         }
 
-        internal bool ReloadWindowsFluentDictionary
+        private bool ReloadWindowsFluentDictionary
         {
             get
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -2128,6 +2128,23 @@ namespace System.Windows
             return ptDeviceUnits;
         }
 
+        internal void AddFluentDictionary(ResourceDictionary value, out bool invalidateResources)
+        {
+            invalidateResources = false;
+            
+            if(this.ReloadWindowsFluentDictionary && !this.IsWindowsResourcesInitialized)
+            {
+                if(value != null) 
+                {
+                    var uri = ThemeManager.GetThemeResource(this.ThemeMode);
+                    value.MergedDictionaries.Insert(0, new ResourceDictionary() { Source = uri });
+                    invalidateResources = true;
+                }
+
+                this.ReloadWindowsFluentDictionary = false;
+            }
+        }
+
         internal static bool VisibilityToBool(Visibility v)
         {
             switch (v)


### PR DESCRIPTION
Similar PR: #49 
Fixes: https://github.com/dotnet/wpf/issues/9557

## Description
The following changes loads the window's fluent resources to make sure that resources can be used as `StaticResource`. This fixes window's scope of the above mentioned issue.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Developers can use fluent resources as `StaticResources`.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
<!-- What kind of testing has been done with the fix. -->
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
